### PR TITLE
Moving pre-commit to a separate workflow

### DIFF
--- a/.github/ci/.pre-commit-config.yaml
+++ b/.github/ci/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: ^proposals/
+# Skip sklearn_penguins until its refactored
+exclude: ^examples/sklearn_penguins/
 default_stages: [push,]
 repos:
 -   repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/.github/ci/.pre-commit-config.yaml
+++ b/.github/ci/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-# Skip sklearn_penguins until its refactored
+# ToDo(gcasassaez): Skip sklearn_penguins until its refactored - https://github.com/tensorflow/tfx-addons/issues/61
 exclude: ^examples/sklearn_penguins/
 default_stages: [push,]
 repos:

--- a/.github/ci/.pre-commit-config.yaml
+++ b/.github/ci/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: ^examples/
+exclude: ^proposals/
 default_stages: [push,]
 repos:
 -   repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - uses: pre-commit/action@v2.0.3
-      name: Run pre-commit checks (pylint/yapf/isort)
-      env:
-        SKIP: insert-license
-      with:
-        extra_args: --hook-stage push --all-files
   pytest-ci:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint 
+
+on:
+  push:
+    paths-ignore:
+      - 'proposals/**'
+    branches:
+      - main
+      - r*
+  pull_request:
+    paths-ignore:
+      - 'proposals/**'
+    branches:
+      - main
+      - r*
+
+jobs:
+  pre-commit-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - uses: pre-commit/action@v2.0.3
+      name: Run pre-commit checks (pylint/yapf/isort)
+      env:
+        SKIP: insert-license
+      with:
+        extra_args: --hook-stage push --all-files


### PR DESCRIPTION
Update to run pre-commit on all examples and separate from pytest CI to be able to be general for all.