### PR TITLE
Propose using automerge in repo

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,15 @@
+name: Automatic merging
+on:
+  pull_request_target: { types: [opened, synchronize] }
+  issue_comment: { types: [created] }
+  pull_request_review: { types: [submitted] }
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run Codeowners merge check
+        uses: casassg/auto-merge-bot@v0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Due to how we currently have set up the repository, only few people can write. 

However, we can automate some of the merges to the repository by using https://github.com/marketplace/actions/auto-merge-bot (based mostly on https://github.com/OSS-Docs-Tools/code-owner-self-merge)

This action uses codeowners file to determine who needs to review the PR and validates that enough users have approved it. 

Once enough approvals happen, the bot will automatically merge it into master. This allows us to develop on the repo without having to ask for @rcrowe-google to review and merge every time!