### PR TITLE
Add documentation for automerge and remove auto-assignation for PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,6 @@ name: Automatic merging
 on:
   pull_request_target: { types: [opened, synchronize] }
   issue_comment: { types: [created] }
-  pull_request_review: { types: [submitted] }
 
 jobs:
   automerge:
@@ -10,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Run Codeowners merge check
-        uses: casassg/auto-merge-bot@v0.2
+        uses: casassg/auto-merge-bot@v0.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Run Codeowners merge check
-        uses: casassg/auto-merge-bot@v0.1
+        uses: casassg/auto-merge-bot@v0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          merge_method: 'squash'
+          assign_reviewer: 'false'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 * @rcrowe-google @mihaimaruseac @theadactyl
 
 # Core team for reviews of project proposals and main distribution files
-# /proposals/ daikeshi@gmail.com casassg hanneshapke junbopark larry.price@openx.com marcromeyn michalbrys nle@twitter.com olgai@spotify.com pselden rclough sngahane
+/proposals/ @rcrowe-google [proposals]
 /tfx_addons/__init__.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane
 /setup.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane
 /pyproject.toml  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,35 +2,35 @@
 * @rcrowe-google @mihaimaruseac @theadactyl
 
 # Core team for reviews of project proposals and main distribution files
-/proposals/ @rcrowe-google [proposals]
-/tfx_addons/__init__.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane [core:distribution]
-/setup.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane [core:distribution]
-/pyproject.toml  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane [core:distribution]
+/proposals/ @rcrowe-google
+/tfx_addons/__init__.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane
+/setup.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane
+/pyproject.toml  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane
 
 
 # CI configuration (for now owned by @casassg)
-/.github/workflows/*.yml @casassg [core:actions]
-/.github/ci  @casassg [core:lint]
+/.github/workflows/*.yml @casassg
+/.github/ci  @casassg
 
 
 # Sci-Kit Learn Example using the Penguins dataset
-/examples/sklearn_penguins/ @TheMichaelHu @1025kb [examples:sklearn_penguins]
+/examples/sklearn_penguins/ @TheMichaelHu @1025kb
 
 # MLMD Client Library
-/tfx_addons/mlmd_client/ @codesue @pselden @casassg [tfxa:mlmd_client]
+/tfx_addons/mlmd_client/ @codesue @pselden @casassg
 
 # ExampleFilter Component
-/tfx_addons/example_filter/ @rclough [tfxa:example_filter]
+/tfx_addons/example_filter/ @rclough
 
 # Schema Curation Component
-/tfx_addons/schema_curation/ @pratishtha-abrol @FatimahAdwan @deutranium @nirzu97 [tfxa:schema_curation]
+/tfx_addons/schema_curation/ @pratishtha-abrol @FatimahAdwan @deutranium @nirzu97
 
 # XGBoost Evaluator Component
-/tfx_addons/xgboost_evaluator @kindalime @cent5 [tfxa:xgboost_evaluator]
-/examples/xgboost_penguins @kindalime @cent5 [examples:xgboost_penguins]
+/tfx_addons/xgboost_evaluator @kindalime @cent5
+/examples/xgboost_penguins @kindalime @cent5
 
 # Sampling Component
-/tfx_addons/sampling @kindalime [tfxa:sampling]
+/tfx_addons/sampling @kindalime
 
 # Feast ExampleGen Component
-/tfx_addons/feast_examplegen @BACtaki [tfxa:feast_examplegen]
+/tfx_addons/feast_examplegen @BACtaki

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,34 +3,34 @@
 
 # Core team for reviews of project proposals and main distribution files
 /proposals/ @rcrowe-google [proposals]
-/tfx_addons/__init__.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane
-/setup.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane
-/pyproject.toml  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane
+/tfx_addons/__init__.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane [core:distribution]
+/setup.py  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane [core:distribution]
+/pyproject.toml  @casassg @hanneshapke @junbopark @marcromeyn @michalbrys @pselden @rclough @sngahane [core:distribution]
 
 
 # CI configuration (for now owned by @casassg)
-/.github/workflows/ci.yml @casassg
-/.github/ci  @casassg
+/.github/workflows/*.yml @casassg [core:actions]
+/.github/ci  @casassg [core:lint]
 
 
 # Sci-Kit Learn Example using the Penguins dataset
-/examples/sklearn_penguins/ @TheMichaelHu @1025kb
+/examples/sklearn_penguins/ @TheMichaelHu @1025kb [examples:sklearn_penguins]
 
 # MLMD Client Library
-/tfx_addons/mlmd_client/ @codesue @pselden @casassg
+/tfx_addons/mlmd_client/ @codesue @pselden @casassg [tfxa:mlmd_client]
 
 # ExampleFilter Component
-/tfx_addons/example_filter/ @rclough
+/tfx_addons/example_filter/ @rclough [tfxa:example_filter]
 
 # Schema Curation Component
-/tfx_addons/schema_curation/ @pratishtha-abrol @FatimahAdwan @deutranium @nirzu97
+/tfx_addons/schema_curation/ @pratishtha-abrol @FatimahAdwan @deutranium @nirzu97 [tfxa:schema_curation]
 
 # XGBoost Evaluator Component
-/tfx_addons/xgboost_evaluator @kindalime @cent5
-/examples/xgboost_penguins @kindalime @cent5
+/tfx_addons/xgboost_evaluator @kindalime @cent5 [tfxa:xgboost_evaluator]
+/examples/xgboost_penguins @kindalime @cent5 [examples:xgboost_penguins]
 
 # Sampling Component
-/tfx_addons/sampling @kindalime
+/tfx_addons/sampling @kindalime [tfxa:sampling]
 
 # Feast ExampleGen Component
-/tfx_addons/feast_examplegen @BACtaki
+/tfx_addons/feast_examplegen @BACtaki [tfxa:feast_examplegen]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,12 @@ just getting started, Github has a [howto](https://help.github.com/articles/usin
 
 SIG team members will be assigned to review your pull requests. Once the pull requests are approved and pass continuous integration checks, we will merge the pull requests.
 
+### Reviewing contributions
+
+- Reviewers can approve pull requests using `/lgtm` command. CODEOWNERS file is used to validate approvals.
+- Reviewers can request an automatic merge using `/merge` command. Auto-merge will be performed after all tests have passed and enough approvals are recollected for the PR.
+- Changes to `.github/workflows` will need to be merged manually by a reviewer with write permissions.
+
 ### Development tips
 
 We use [pre-commit](https://pre-commit.com/) to validate our code before we push to the repository. We use push over commit to allow more flexibility.


### PR DESCRIPTION
Adds some documentation for automerge and setup for auto-labeling PRs


In addition, also upgraded the bot to avoid assigning reviewers for now (to avoid too much noise for contributors) and set it up to squash when merging (instead of merge) to have a cleaner main branch.

