### PR TITLE
added vulkomilev to the CODEOWNERS for CI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,8 +9,8 @@
 
 
 # CI configuration (for now owned by @casassg)
-/.github/workflows/*.yml @casassg
-/.github/ci  @casassg
+/.github/workflows/*.yml @casassg @vulkomilev
+/.github/ci  @casassg @vulkomilev
 
 
 # Sci-Kit Learn Example using the Penguins dataset


### PR DESCRIPTION
Added @vulkomilev in the CODEOWNER for CI next to @casassg

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR