### PR TITLE
Remove pyarrow note

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,10 @@ jobs:
       # Test for several versions of TFX in parallel
       # keep constraints in sync with version.py
       matrix:
-        # NB(gcasassaez): TF 2.8 moves numpy to >=1.20 wich doesnt work for pyarrow<3
-        # See: https://issues.apache.org/jira/browse/ARROW-11450
         depconstraint: [
           "tfx~=1.0.0 tensorflow~=2.5.0"
           "tfx~=1.4.0 tensorflow~=2.6.0",
-          "tfx~=1.7.0 tensorflow~=2.8.0 pyarrow~=3.0.0",
+          "tfx~=1.7.0 tensorflow~=2.8.0",
         ]
         extras: ["all, test"]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,10 @@ jobs:
       # Test for several versions of TFX in parallel
       # keep constraints in sync with version.py
       matrix:
-        depconstraint: [
-          "tfx~=1.0.0 tensorflow~=2.5.0"
-          "tfx~=1.4.0 tensorflow~=2.6.0",
-          "tfx~=1.7.0 tensorflow~=2.8.0",
-        ]
+        depconstraint: 
+          - "tfx~=1.0.0 tensorflow~=2.5.0"
+          - "tfx~=1.4.0 tensorflow~=2.6.0"
+          - "tfx~=1.7.0 tensorflow~=2.8.0"
         extras: ["all, test"]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       # keep constraints in sync with version.py
       matrix:
         depconstraint: 
-          - "tfx~=1.0.0 tensorflow~=2.5.0"
           - "tfx~=1.4.0 tensorflow~=2.6.0"
           - "tfx~=1.7.0 tensorflow~=2.8.0"
         extras: ["all, test"]


### PR DESCRIPTION
My hypothesis is now we should be able to just use the normal constraint as pip installs from scratch either way. So no cache.
