### PR TITLE
removed _VERSION_SUFFIX to trigger first release

### DIFF
--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -30,7 +30,7 @@ _PATCH_VERSION = "0"
 # stable release (indicated by `_VERSION_SUFFIX = ''`). Outside the context of a
 # release branch, the current version is by default assumed to be a
 # 'development' version, labeled 'dev'.
-_VERSION_SUFFIX = "dev"
+_VERSION_SUFFIX = ""
 
 # Example, '0.1.0-dev'
 __version__ = ".".join([_MAJOR_VERSION, _MINOR_VERSION, _PATCH_VERSION])

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -30,7 +30,7 @@ _PATCH_VERSION = "0"
 # stable release (indicated by `_VERSION_SUFFIX = ''`). Outside the context of a
 # release branch, the current version is by default assumed to be a
 # 'development' version, labeled 'dev'.
-_VERSION_SUFFIX = ""
+_VERSION_SUFFIX = "rc0"
 
 # Example, '0.1.0-dev'
 __version__ = ".".join([_MAJOR_VERSION, _MINOR_VERSION, _PATCH_VERSION])


### PR DESCRIPTION
Removing the suffix it will trigger the creation of the 0.1.0 version once merged into `main`.