### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,12 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Upload files to a GitHub release
+      uses: svenstaro/upload-release-action@2.2.1
+      if: github.event_name == 'release'
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: dist/*
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,27 @@
 name: Release TFX Addons package to PyPI and TestPyPI
 
 on:
-  workflow_run:
-    workflows: ["TFX Addons package CI", "Lint"]
-    branches: [main]
-    types:
-      - completed
+  push:
+    paths:
+      - 'tfx_addons/**'
+      - 'setup.py'
+      - 'pyproject.toml'
+    branches:
+      - main
+      - r*
+  release:
+    types: [published]
+    tags:
+      - v*
 
 jobs:
   build-and-publish:
     name: Build TFX Addons PyPI package and release to PyPI and TestPyPI
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install pypa/build
@@ -22,12 +29,13 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python -m build --sdist --wheel --outdir dist/ .
     - name: Publish distribution TFX Addons package to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
     - name: Publish distribution TFX Addons package to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      if: github.event_name == 'release'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@ TFX Addons follows [Semantic Versioning 2.0](https://semver.org/) strategy.
 3. Create a [new release](https://github.com/tensorflow/tfx-addons/releases) from `rX.Y` branch. Create a tag with `vX.Y.Z` name.
     * Add updates for new features, enhancements, bug fixes
     * Add contributors using `git shortlog <last-version>..HEAD -s`
+4. Create a new PR and merge an increase of `_MINOR_VERSION` number in `main` to get ready for next release.
 
 ## Patch releases
 1. Cherry-pick commits to `rX.Y` branch

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,19 +1,29 @@
 # SIG Addons Releases
 
-SIG TFX Addons release process consists of the folowing steps:
+TFX Addons follows [Semantic Versioning 2.0](https://semver.org/) strategy.
 
-The idea is to merge feature PR into a release branch, which is later merged into the main/master branch.
+## Major/Minor releases
 
-1. Create new rX.X branch on https://github.com/tensorflow/tfx-addons
-2. Create and merge a new PR into the release branch
-	* Set the correct version and suffix in [version.py](https://github.com/tensorflow/tfx-addons/blob/master/tensorflow_addons/version.py)
-	* Ensure the proper minimum and maximum tested versions of TFX are set in [version.py](https://github.com/tensorflow/tfx-addons/blob/master/tfx_addons/version.py)
-	* Ensure proper supported python libraries are set in [setup.py](https://github.com/tensorflow/addons/blob/master/setup.py)
-3. Create and merge a new PR to merge rX.X branch to main/master
-4. Publish and tag a [release on Github](https://github.com/tensorflow/tfx-addons/releases)
+1. Create new `rX.Y` branch on https://github.com/tensorflow/tfx-addons from `main`.
+2. Create new PR with updates to `version.py` against `rX.Y` branch.
+	* Set the correct version and suffix in [version.py](https://github.com/tensorflow/tfx-addons/blob/master/tensorflow_addons/version.py).
+	* Ensure the proper minimum and maximum tested versions of TFX are set in [version.py](https://github.com/tensorflow/tfx-addons/blob/master/tfx_addons/version.py).
+	* Ensure proper supported python libraries are set in [setup.py](https://github.com/tensorflow/addons/blob/master/setup.py).
+3. Create a [new release](https://github.com/tensorflow/tfx-addons/releases) from `rX.Y` branch. Create a tag with `vX.Y.Z` name.
     * Add updates for new features, enhancements, bug fixes
     * Add contributors using `git shortlog <last-version>..HEAD -s`
-    * TODO: **NOTE: This will trigger a GitHub action to release the wheels on PyPi**
+
+## Patch releases
+1. Cherry-pick commits to `rX.Y` branch
+2. Create new PR with increasing `_PATCH_VERSION` in `version.py` against `rX.Y` branch.
+	* Set the correct version and suffix in [version.py](https://github.com/tensorflow/tfx-addons/blob/master/tensorflow_addons/version.py).
+	* Ensure the proper minimum and maximum tested versions of TFX are set in [version.py](https://github.com/tensorflow/tfx-addons/blob/master/tfx_addons/version.py).
+	* Ensure proper supported python libraries are set in [setup.py](https://github.com/tensorflow/addons/blob/master/setup.py).
+3. Create a [new release](https://github.com/tensorflow/tfx-addons/releases) from `rX.Y` branch. Create a tag with `vX.Y.Z` name.
+    * Add updates for new features, enhancements, bug fixes
+    * Add contributors using `git shortlog <last-version>..HEAD -s`
+
+
 
 ## SIG Addons Release Team
 


### PR DESCRIPTION
The current release format won't work since only commits tagged in main will work. 

Alternatively, we just release whenever a release is created from the releases page. Which is provides a more reproducible default. 