### PR TITLE
Release 0.1.0

### DIFF
--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -30,7 +30,7 @@ _PATCH_VERSION = "0"
 # stable release (indicated by `_VERSION_SUFFIX = ''`). Outside the context of a
 # release branch, the current version is by default assumed to be a
 # 'development' version, labeled 'dev'.
-_VERSION_SUFFIX = "rc3"
+_VERSION_SUFFIX = ""
 
 # Example, '0.1.0-dev'
 __version__ = ".".join([_MAJOR_VERSION, _MINOR_VERSION, _PATCH_VERSION])


### PR DESCRIPTION
Release 0.1.0 based on 0.1.0rc3.

Once merged:
- Trigger a new GitHub Release using 0.1.0 as release name and tag.