### PR TITLE
Improve TFX Addons README, creates tfx_addons.{module} root imports and fix xgboost penguin example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: TFX Addons package CI
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci_examples.yml
+++ b/.github/workflows/ci_examples.yml
@@ -1,4 +1,4 @@
-name: TFX Addons CI for examples
+name: Examples CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -2,28 +2,73 @@
 
 [![TFX Addons package CI](https://github.com/tensorflow/tfx-addons/actions/workflows/ci.yml/badge.svg)](https://github.com/tensorflow/tfx-addons/actions/workflows/ci.yml)
 [![TFX Addons CI for examples](https://github.com/tensorflow/tfx-addons/actions/workflows/ci_examples.yml/badge.svg)](https://github.com/tensorflow/tfx-addons/actions/workflows/ci_examples.yml)
+[![PyPI](https://badge.fury.io/py/tfx-addons.svg)](https://badge.fury.io/py/tfx-addons)
 
-## TL;DR
-This is the repo for projects organized under the special interest group, SIG TFX-Addons. Join the group by [joining the Google Group](http://goo.gle/tfx-addons-group) and participate in projects to build new components, libraries, tools, and other useful additions to TFX.
 
-## Context
-Machine learning in production environments is a mission-critical part of a growing number of products and services across many industries. To become an [AI First company](https://ai.google/), Google required a state-of-the-art production ML infrastructure framework, and created TensorFlow Extended (TFX). Google open-sourced TFX in 2019 to enable other developers worldwide to benefit from and help us improve the TFX framework, and established open layers within the TFX architecture specifically focused at customization for a wide range of developer needs. These include custom pipeline components, containers, templates, and orchestrator support.
+SIG TFX-Addons is a community-led open source project. As such, the project depends on public contributions, bug fixes, and documentation. This project adheres to the [TensorFlow Code of Conduct](https://github.com/tensorflow/tensorflow/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
-In order to accelerate the sharing of community customizations and additions to TFX, the TFX team would like to encourage, enable, and organize community contributions to help continue to meet the needs of production ML, expand the vision, and help drive new directions for TFX and the ML community.
+## Maintainership
 
-## Goals & Objectives
-We welcome community contributions on any area of TFX, but this SIG will initially focus on the following goals:
+The maintainers of TensorFlow Addons can be found in the [CODEOWNERS](CODEOWNERS) file of the repo. If you would
+like to maintain something, please feel free to submit a PR. We encourage multiple 
+owners for all submodules.
 
-- Driving the development of high-quality custom pipeline components, including Python function-based components, container-based components, and fully custom components.
-- Shaping a standardized set of descriptive metadata for community-contributed components to enable easy understanding, comparison, and sharing of components during discovery.
-- Similarly driving the development of templates, libraries, visualizations, and other useful additions to TFX.
 
-These projects will begin as proposals to the SIG, and upon approval will be led and maintained by the community members involved in the project and assigned a project folder, with high-level consultation from the TFX team.
+## Installation
 
-### In-Scope, Out of Scope
-Although TFX is an open-source project and we welcome contributions to TFX itself, **this SIG does not include contributions or additions to core TFX**.  It is focused only on building community-contributed and maintained additions on top of core TFX.  [Core TFX has its own repo](https://github.com/tensorflow/tfx), and PRs and issues will continue to be managed there. **In addition, all contributions must not violate the [Google AI Principles](https://ai.google/principles/) or [Responsible AI Practices](https://ai.google/responsibilities/responsible-ai-practices/).**
+TFX Addons is available on PyPI for all OS. To install the latest version, 
+run the following:
+```
+pip install tfx-addons
+```
 
-## Membership
+To ensure you have a compatible version of dependencies for any given project, 
+you can specify the project name  as an extra requirement during install:
+
+```
+pip install tfx-addons[feast_examplegen,schema_curation]
+``` 
+
+To use TFX Addons:
+
+```python
+from tfx import v1 as tfx
+import tfx_addons as tfxa
+```
+
+
+## Addons Subpackages
+
+* [tfxa.mlmd_client](tfx_addons/mlmd_client) 
+* [tfxa.schema_curation](tfx_addons/schema_curation) 
+* [tfxa.feast_examplegen](tfx_addons/feast_examplegen) 
+* [tfxa.xgboost_evaluator](tfx_addons/xgboost_evaluator)
+* [tfxa.sampling](tfx_addons/sampling)
+* [tfxa.message_exit_handler](tfx_addons/message_exit_handler) 
+
+
+
+## Tutorials and examples
+See [`examples/`](examples/)
+for end-to-end examples of various addons.
+
+## Maintainership
+
+TFX Addons has been designed to compartmentalize submodules so 
+that they can be maintained by community users who have expertise, and a vested 
+interest in that component. We heavily encourage users to submit sign up to maintain a 
+submodule by submitting your username to the [CODEOWNERS](CODEOWNERS) file.
+
+Full write access will only be granted after substantial contribution 
+has been made in order to limit the number of users with write permission. 
+Contributions can come in the form of issue closings, bug fixes, documentation, 
+new code, or optimizing existing code. Submodule maintainership can be granted 
+with a lower barrier for entry as this will not include write permissions to 
+the repo.
+
+
+### SIG Membership
+
 We encourage any developers working in production ML environments, infrastructure, or applications to [join and participate in the activities of the SIG](http://goo.gle/tfx-addons-group). Whether you are working on advancing the platform, prototyping or building specific applications, or authoring new components, templates, libraries, and/or orchestrator support, we welcome your feedback on and contributions to TFX and its tooling, and are eager to hear about any downstream results, implementations, and extensions.
 
 We have multiple channels for participation, and publicly archive discussions in our user group mailing list:
@@ -34,26 +79,14 @@ We have multiple channels for participation, and publicly archive discussions in
 Other Resources
 - SIG Repository: http://github.com/tensorflow/tfx-addons (this repo)
 - Documentation: https://www.tensorflow.org/tfx
+- SIG Charter:  https://github.com/tensorflow/community/blob/master/sigs/tfx-addons/CHARTER.md
 
-## Organization and Governance
-This is the repo for individual SIG projects and contributions.  It also contains overall SIG documents and resources, which are managed by the TensorFlow team.  Individual contribution projects will begin as proposals to the SIG, and once approved a folder will be created for the project, and project leaders assigned permissions to manage the folder.  **Projects will be led, maintained, and be the responsibility of community project leaders. Google and the TensorFlow team will not provide user support or maintenance for contributed addons. The TFX team will support community maintainers in SIG operations and contribution infrastructure.**
+Meeting cadence:
+- Bi-weekly on Wednesday. [Meeting notes](https://docs.google.com/document/d/1T0uZPoZhwNStuKkeCNsfE-kfc-PINISKIitYxkTK3Gw/edit?resourcekey=0-N9vT9Tn171wYplyYn4IPjQ)
 
-Individual projects will be assigned a new folder, where all project materials will live. For all community-contributed projects the source of truth will be those project folders. Project leaders will be identified in CODEOWNERS. New project leaders will be recruited for abandoned projects, or if new leaders are not found then projects will be deprecated and archived. Statistics will be generated and reported per-project.
 
-SIG TFX-Addons is a community-led open source project. As such, the project depends on public contributions, bug fixes, and documentation. This project adheres to the [TensorFlow Code of Conduct](https://github.com/tensorflow/tensorflow/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+### Periodic Evaluation of Components and Examples
 
-## Project Approvals
-1. Project proposals will be submitted to the SIG and published for open review and comment by SIG members for 2 weeks.
-2. Following review and approval by the Google TFX team, core team members will vote either in person or offline on whether to approve or reject project proposals.
-3. All projects must meet the following criteria:
-   - Team members must be named in the proposal
-   - All team members must have completed a [Contributor License Agreement](https://cla.developers.google.com/)
-   - The project must not violate the [TensorFlow Code of Conduct](https://github.com/tensorflow/tensorflow/blob/master/CODE_OF_CONDUCT.md), [Google AI Principles](https://ai.google/principles/) or [Responsible AI Practices](https://ai.google/responsibilities/responsible-ai-practices/).
-4. Projects must code to supported open interfaces only, and not reach into core TFX to make changes or rely on private classes, methods, properties, or interfaces.
-5. **Google retains the right to reject any proposal.**
-6. Projects must first be approved by the Google team.  Projects are then sent for approval to the core community team.  Projects will be approved with a minimum of three `+1` votes, but can be sent for changes and re-review with a single `-1` vote.
-
-## Periodic Evaluation of Components and Examples
 Components may become less and less useful to the community and TFX examples might become outdated as future TFX versions are released. In order to keep the repository sustainable, we'll be performing bi-annual reviews of our code to ensure everything still belongs within the repo. Contributing factors to this review will be:
 
 1. Number of active maintainers
@@ -71,25 +104,13 @@ The status change between these three groups is: Suggested <-> Discouraged -> De
 The period between an API being marked as deprecated and being deleted will be 90 days. The rationale being:
 In the event that TFX Addons releases monthly, there will be 2-3 releases before an API is deleted. The release notes could give user enough warning. 90 days gives maintainers ample time to fix their code.
 
-## Contacts
-- Project Lead:
-  - Robert Crowe (Google)
-- Community Lead(s)
-  - Hannes Hapke (Digits)
-- Core Team Members:
-  - Paul Selden (OpenX)
-  - Gerard Casas Saez (Twitter)
-  - Newton Le (Twitter)
-  - David Xia (Spotify)
-  - Jonathan Jin (Spotify)
-  - Michal Brys (OpenX)
-  -  Baris Can Durak (ZenML)
-  -  Hamza Tahir (ZenML)
-  -  Larry Price (OpenX)
-- Administrative questions:
-  - Thea Lamkin (Google): thealamkin at google dot com
-  - Joana Carrasqueira (Google): joanafilipa at google dot com
-  - tf-community at tensorflow dot org
-
-Meeting cadence:
-- TBD
+### Project Approvals
+1. Project proposals will be submitted to the SIG and published for open review and comment by SIG members for 2 weeks.
+2. Following review and approval by the Google TFX team, core team members will vote either in person or offline on whether to approve or reject project proposals.
+3. All projects must meet the following criteria:
+   - Team members must be named in the proposal
+   - All team members must have completed a [Contributor License Agreement](https://cla.developers.google.com/)
+   - The project must not violate the [TensorFlow Code of Conduct](https://github.com/tensorflow/tensorflow/blob/master/CODE_OF_CONDUCT.md), [Google AI Principles](https://ai.google/principles/) or [Responsible AI Practices](https://ai.google/responsibilities/responsible-ai-practices/).
+4. Projects must code to supported open interfaces only, and not reach into core TFX to make changes or rely on private classes, methods, properties, or interfaces.
+5. **Google retains the right to reject any proposal.**
+6. Projects must first be approved by the Google team.  Projects are then sent for approval to the core community team.  Projects will be approved with a minimum of three `+1` votes, but can be sent for changes and re-review with a single `-1` vote.

--- a/examples/xgboost_penguins/penguin_pipeline_local.py
+++ b/examples/xgboost_penguins/penguin_pipeline_local.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,10 +22,11 @@ import os
 from pathlib import Path
 from typing import List, Text
 
+import tensorflow_model_analysis as tfma
 from absl import logging
 from tfx import v1 as tfx
+
 import tfx_addons as tfxa
-import tensorflow_model_analysis as tfma
 
 _pipeline_name = 'penguin_xgboost_local'
 
@@ -105,20 +106,20 @@ def create_pipeline(
   # Uses TFMA to compute evaluation statistics over features of a model and
   # perform quality validation of a candidate model (compared to a baseline).
   eval_config = tfma.EvalConfig(
-    model_specs=[tfma.ModelSpec(name=None, label_key='species')],
-    slicing_specs=[tfma.SlicingSpec()],
-    metrics_specs=[
-      tfma.MetricsSpec(metrics=[
-          tfma.MetricConfig(
-              class_name='Accuracy',
-              threshold=tfma.MetricThreshold(
-                  value_threshold=tfma.GenericValueThreshold(
-                      lower_bound={'value': 0.6}),
-                  change_threshold=tfma.GenericChangeThreshold(
-                      direction=tfma.MetricDirection.HIGHER_IS_BETTER,
-                      absolute={'value': -1e-10})))
+      model_specs=[tfma.ModelSpec(label_key='species')],
+      slicing_specs=[tfma.SlicingSpec()],
+      metrics_specs=[
+          tfma.MetricsSpec(metrics=[
+              tfma.MetricConfig(
+                  class_name='Accuracy',
+                  threshold=tfma.MetricThreshold(
+                      value_threshold=tfma.GenericValueThreshold(
+                          lower_bound={'value': 0.6}),
+                      change_threshold=tfma.GenericChangeThreshold(
+                          direction=tfma.MetricDirection.HIGHER_IS_BETTER,
+                          absolute={'value': -1e-10})))
+          ])
       ])
-  ])
   evaluator = tfxa.xgboost_evaluator.XGBoostEvaluator(
       model=trainer.outputs["model"],
       eval_config=eval_config,

--- a/examples/xgboost_penguins/penguin_pipeline_local.py
+++ b/examples/xgboost_penguins/penguin_pipeline_local.py
@@ -105,7 +105,6 @@ def create_pipeline(
   # Uses TFMA to compute evaluation statistics over features of a model and
   # perform quality validation of a candidate model (compared to a baseline).
   eval_config = tfma.EvalConfig(
-    model_specs=[tfma.ModelSpec(label_key='species')],
     slicing_specs=[tfma.SlicingSpec()],
     metrics_specs=[
       tfma.MetricsSpec(metrics=[

--- a/examples/xgboost_penguins/penguin_pipeline_local.py
+++ b/examples/xgboost_penguins/penguin_pipeline_local.py
@@ -105,6 +105,7 @@ def create_pipeline(
   # Uses TFMA to compute evaluation statistics over features of a model and
   # perform quality validation of a candidate model (compared to a baseline).
   eval_config = tfma.EvalConfig(
+    model_specs=[tfma.ModelSpec(name=None, label_key='species')],
     slicing_specs=[tfma.SlicingSpec()],
     metrics_specs=[
       tfma.MetricsSpec(metrics=[

--- a/examples/xgboost_penguins/penguin_pipeline_local.py
+++ b/examples/xgboost_penguins/penguin_pipeline_local.py
@@ -118,7 +118,7 @@ def create_pipeline(
                       absolute={'value': -1e-10})))
       ])
   ])
-  tfxa.xgboost_evaluator.XGBoostEvaluator(
+  evaluator = tfxa.xgboost_evaluator.XGBoostEvaluator(
       model=trainer.outputs["model"],
       eval_config=eval_config,
       examples=example_gen.outputs['examples'],
@@ -133,6 +133,7 @@ def create_pipeline(
           schema_gen,
           example_validator,
           trainer,
+          evaluator,
       ],
       enable_cache=True,
       metadata_connection_config=tfx.orchestration.metadata.

--- a/examples/xgboost_penguins/penguin_pipeline_local.py
+++ b/examples/xgboost_penguins/penguin_pipeline_local.py
@@ -25,6 +25,7 @@ from typing import List, Text
 from absl import logging
 from tfx import v1 as tfx
 import tfx_addons as tfxa
+import tensorflow_model_analysis as tfma
 
 _pipeline_name = 'penguin_xgboost_local'
 

--- a/examples/xgboost_penguins/penguin_pipeline_local_e2e_test.py
+++ b/examples/xgboost_penguins/penguin_pipeline_local_e2e_test.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ class PenguinPipelineLocalEndToEndTest(tf.test.TestCase):
             beam_pipeline_args=[]))
 
     self.assertTrue(tfx.dsl.io.fileio.exists(self._metadata_path))
-    expected_execution_count = 5
+    expected_execution_count = 6
     metadata_config = (
         tfx.orchestration.metadata.sqlite_metadata_connection_config(
             self._metadata_path))

--- a/examples/xgboost_penguins/utils.py
+++ b/examples/xgboost_penguins/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -92,6 +92,7 @@ def _train(fn_args, x_train, y_train, x_eval, y_eval):
       num_boost_round=fn_args.custom_config['num_boost_round'],
       early_stopping_rounds=fn_args.custom_config['early_stopping_rounds'],
       evals=[(matrix_eval, 'eval')])
+  model.feature_names = _FEATURE_KEYS
   return model
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,14 +21,14 @@ from setuptools import find_namespace_packages, setup
 PROJECT_NAME = "tfx-addons"
 
 
-def get_project_version():
+def get_pkg_metadata():
   # Version
   extracted_version = {}
   base_dir = os.path.dirname(os.path.abspath(__file__))
   with open(os.path.join(base_dir, "tfx_addons", "version.py")) as fp:
     exec(fp.read(), extracted_version)  # pylint: disable=exec-used
 
-  return extracted_version
+  return extracted_version["_PKG_METADATA"]
 
 
 def get_long_description():
@@ -36,42 +36,9 @@ def get_long_description():
   with open(os.path.join(base_dir, "README.md")) as fp:
     return fp.read()
 
-
-version = get_project_version()
-inclusive_min_tfx_version = version["INCLUSIVE_MIN_TFX_VERSION"]
-exclusive_max_tfx_version = version["EXCLUSIVE_MAX_TFX_VERSION"]
-
 TESTS_REQUIRE = ["pytest", "pylint", "pre-commit", "isort", "yapf"]
 
-required_tfx_version = "tfx>={},<{}".format(inclusive_min_tfx_version,
-                                            exclusive_max_tfx_version)
-required_ml_pipelines_sdk_version = "ml_pipelines_sdk>={},<{}".format(
-    inclusive_min_tfx_version, exclusive_max_tfx_version)
-required_ml_metadata_version = "ml_metadata>={},<{}".format(
-    inclusive_min_tfx_version, exclusive_max_tfx_version)
-
-PKG_REQUIRES = {
-    # Add dependencies here for your project. Avoid using install_requires.
-    "mlmd_client":
-    [required_ml_pipelines_sdk_version, required_ml_metadata_version],
-    "schema_curation": [
-        required_tfx_version,
-    ],
-    "feast_examplegen": [
-        required_tfx_version,
-        "feast>=0.16.0,<1.0.0",
-    ],
-    "xgboost_evaluator": [
-        required_tfx_version,
-        "xgboost>=1.0.0",
-    ],
-    "sampler": ["tensorflow>=2.0.0"],
-    "message_exit_handler": [
-        "kfp>=1.8,<1.9",
-        "slackclient>=2.9.0",
-        "pydantic>=1.8.0",
-    ],
-}
+PKG_REQUIRES = get_pkg_metadata()
 EXTRAS_REQUIRE = PKG_REQUIRES.copy()
 EXTRAS_REQUIRE["all"] = list(
     set(itertools.chain.from_iterable(list(PKG_REQUIRES.values()))))

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,21 @@ PROJECT_NAME = "tfx-addons"
 
 def get_pkg_metadata():
   # Version
-  extracted_version = {}
+  context = {}
   base_dir = os.path.dirname(os.path.abspath(__file__))
   with open(os.path.join(base_dir, "tfx_addons", "version.py")) as fp:
-    exec(fp.read(), extracted_version)  # pylint: disable=exec-used
+    exec(fp.read(), context)  # pylint: disable=exec-used
 
-  return extracted_version["_PKG_METADATA"]
+  return context["_PKG_METADATA"]
+
+def get_version():
+  # Version
+  context = {}
+  base_dir = os.path.dirname(os.path.abspath(__file__))
+  with open(os.path.join(base_dir, "tfx_addons", "version.py")) as fp:
+    exec(fp.read(), context)  # pylint: disable=exec-used
+
+  return context["__version__"]
 
 
 def get_long_description():
@@ -46,7 +55,7 @@ EXTRAS_REQUIRE["test"] = TESTS_REQUIRE
 
 setup(
     name=PROJECT_NAME,
-    version=version["__version__"],
+    version=get_version(),
     description="TFX Addons libraries",
     author="The Tensorflow Authors",
     long_description=get_long_description(),

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ def get_pkg_metadata():
 
   return context["_PKG_METADATA"]
 
+
 def get_version():
   # Version
   context = {}
@@ -44,6 +45,7 @@ def get_long_description():
   base_dir = os.path.dirname(os.path.abspath(__file__))
   with open(os.path.join(base_dir, "README.md")) as fp:
     return fp.read()
+
 
 TESTS_REQUIRE = ["pytest", "pylint", "pre-commit", "isort", "yapf"]
 

--- a/tfx_addons/__init__.py
+++ b/tfx_addons/__init__.py
@@ -14,4 +14,16 @@
 # ==============================================================================
 """Init module for TFX."""
 
-from .version import __version__
+from .version import __version__, _PKG_METADATA
+
+__all__ = [
+    "__version__",
+] + __PKG_METADATA.keys()
+
+def __getattr__(name):
+    # PEP-562: Lazy loaded attributes on python modules
+    # NB(gcasassaez): We lazy load to avoid issues with dependencies not installed
+    # for some subpackes
+    if name in __all__:
+         return importlib.import_module("." + name, __name__)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tfx_addons/__init__.py
+++ b/tfx_addons/__init__.py
@@ -15,6 +15,7 @@
 """Init module for TFX."""
 
 from .version import __version__, _PKG_METADATA
+import importlib as _importlib
 
 _ACTIVE_MODULES = [
     "__version__",
@@ -25,5 +26,5 @@ def __getattr__(name):
     # NB(gcasassaez): We lazy load to avoid issues with dependencies not installed
     # for some subpackes
     if name in _ACTIVE_MODULES:
-         return importlib.import_module("." + name, __name__)
+         return _importlib.import_module("." + name, __name__)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tfx_addons/__init__.py
+++ b/tfx_addons/__init__.py
@@ -16,14 +16,14 @@
 
 from .version import __version__, _PKG_METADATA
 
-__all__ = [
+_ACTIVE_MODULES = [
     "__version__",
-] + _PKG_METADATA.keys()
+] + list(_PKG_METADATA.keys())
 
 def __getattr__(name):
     # PEP-562: Lazy loaded attributes on python modules
     # NB(gcasassaez): We lazy load to avoid issues with dependencies not installed
     # for some subpackes
-    if name in __all__:
+    if name in _ACTIVE_MODULES:
          return importlib.import_module("." + name, __name__)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tfx_addons/__init__.py
+++ b/tfx_addons/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,17 +14,19 @@
 # ==============================================================================
 """Init module for TFX."""
 
-from .version import __version__, _PKG_METADATA
 import importlib as _importlib
+
+from .version import _PKG_METADATA, __version__
 
 _ACTIVE_MODULES = [
     "__version__",
 ] + list(_PKG_METADATA.keys())
 
-def __getattr__(name):
-    # PEP-562: Lazy loaded attributes on python modules
-    # NB(gcasassaez): We lazy load to avoid issues with dependencies not installed
-    # for some subpackes
-    if name in _ACTIVE_MODULES:
-         return _importlib.import_module("." + name, __name__)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+def __getattr__(name):  # pylint: disable=C0103
+  # PEP-562: Lazy loaded attributes on python modules
+  # NB(gcasassaez): We lazy load to avoid issues with dependencies not installed
+  # for some subpackes
+  if name in _ACTIVE_MODULES:
+    return _importlib.import_module("." + name, __name__)
+  raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tfx_addons/__init__.py
+++ b/tfx_addons/__init__.py
@@ -18,7 +18,7 @@ from .version import __version__, _PKG_METADATA
 
 __all__ = [
     "__version__",
-] + __PKG_METADATA.keys()
+] + _PKG_METADATA.keys()
 
 def __getattr__(name):
     # PEP-562: Lazy loaded attributes on python modules

--- a/tfx_addons/mlmd_client/__init__.py
+++ b/tfx_addons/mlmd_client/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-__all__ = [
-    "MetadataClient"
-]
+"""MLMDClient module"""
+__all__ = ["MetadataClient"]
 from .client import MetadataClient

--- a/tfx_addons/mlmd_client/__init__.py
+++ b/tfx_addons/mlmd_client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 __all__ = [
-    "XGBoostEvaluator"
+    "MetadataClient"
 ]
-from .component import XGBoostEvaluator
+from .client import MetadataClient

--- a/tfx_addons/sampling/__init__.py
+++ b/tfx_addons/sampling/__init__.py
@@ -12,3 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+__all__ = [
+    "Sampler",
+]
+
+
+from .component import Sampler

--- a/tfx_addons/sampling/__init__.py
+++ b/tfx_addons/sampling/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+"""Sampling component"""
 __all__ = [
     "Sampler",
 ]
-
 
 from .component import Sampler

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -39,10 +39,6 @@ if _VERSION_SUFFIX:
 _INCLUSIVE_MIN_TFX_VERSION = "1.4.0"
 _EXCLUSIVE_MAX_TFX_VERSION = "1.8.0"
 _TFXVERSION_CONSTRAINT = f">={_INCLUSIVE_MIN_TFX_VERSION},<{_EXCLUSIVE_MAX_TFX_VERSION}"
-required_ml_pipelines_sdk_version = "ml_pipelines_sdk>={},<{}".format(
-    inclusive_min_tfx_version, exclusive_max_tfx_version)
-required_ml_metadata_version = "ml_metadata>={},<{}".format(
-    inclusive_min_tfx_version, exclusive_max_tfx_version)
 
 _PKG_METADATA = {
     # Add dependencies here for your project. Avoid using install_requires.

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -16,9 +16,6 @@
 # ==============================================================================
 """Define TFX Addons version information."""
 
-# Required TFX version [min, max), keep depconstraint in ci.yml in sync
-INCLUSIVE_MIN_TFX_VERSION = "1.4.0"
-EXCLUSIVE_MAX_TFX_VERSION = "1.8.0"
 
 # We follow Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = "0"
@@ -36,3 +33,36 @@ _VERSION_SUFFIX = "dev"
 __version__ = ".".join([_MAJOR_VERSION, _MINOR_VERSION, _PATCH_VERSION])
 if _VERSION_SUFFIX:
   __version__ = "{}-{}".format(__version__, _VERSION_SUFFIX)
+
+
+# Required TFX version [min, max), keep depconstraint in ci.yml in sync
+_INCLUSIVE_MIN_TFX_VERSION = "1.4.0"
+_EXCLUSIVE_MAX_TFX_VERSION = "1.8.0"
+_TFXVERSION_CONSTRAINT = f">={_INCLUSIVE_MIN_TFX_VERSION},<{_EXCLUSIVE_MAX_TFX_VERSION}"
+required_ml_pipelines_sdk_version = "ml_pipelines_sdk>={},<{}".format(
+    inclusive_min_tfx_version, exclusive_max_tfx_version)
+required_ml_metadata_version = "ml_metadata>={},<{}".format(
+    inclusive_min_tfx_version, exclusive_max_tfx_version)
+
+_PKG_METADATA = {
+    # Add dependencies here for your project. Avoid using install_requires.
+    "mlmd_client":
+    [f"ml_pipelines_sdk{_TFXVERSION_CONSTRAINT}", f"ml_metadata{_TFXVERSION_CONSTRAINT}"],
+    "schema_curation": [
+        f"tfx{_TFXVERSION_CONSTRAINT}",
+    ],
+    "feast_examplegen": [
+        f"tfx{_TFXVERSION_CONSTRAINT}",
+        "feast>=0.16.0,<1.0.0",
+    ],
+    "xgboost_evaluator": [
+         f"tfx{_TFXVERSION_CONSTRAINT}",
+        "xgboost>=1.0.0",
+    ],
+    "sampling": [f"tfx{_TFXVERSION_CONSTRAINT}", "tensorflow>=2.0.0"],
+    "message_exit_handler": [
+        f"tfx{_TFXVERSION_CONSTRAINT}",
+        "slackclient>=2.9.0",
+        "pydantic>=1.8.0",
+    ],
+}

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -1,13 +1,11 @@
 # Copyright 2022 The TensorFlow Authors. All Rights Reserved.
-
-# TODO: This license is not consistent with license used in the project.
-#       Delete the inconsistent license and above line and rerun pre-commit to insert a good license.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Define TFX Addons version information."""
-
 
 # We follow Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = "0"
@@ -34,16 +31,18 @@ __version__ = ".".join([_MAJOR_VERSION, _MINOR_VERSION, _PATCH_VERSION])
 if _VERSION_SUFFIX:
   __version__ = "{}-{}".format(__version__, _VERSION_SUFFIX)
 
-
 # Required TFX version [min, max), keep depconstraint in ci.yml in sync
 _INCLUSIVE_MIN_TFX_VERSION = "1.4.0"
 _EXCLUSIVE_MAX_TFX_VERSION = "1.8.0"
-_TFXVERSION_CONSTRAINT = f">={_INCLUSIVE_MIN_TFX_VERSION},<{_EXCLUSIVE_MAX_TFX_VERSION}"
+_TFXVERSION_CONSTRAINT = (
+    f">={_INCLUSIVE_MIN_TFX_VERSION},<{_EXCLUSIVE_MAX_TFX_VERSION}")
 
 _PKG_METADATA = {
     # Add dependencies here for your project. Avoid using install_requires.
-    "mlmd_client":
-    [f"ml_pipelines_sdk{_TFXVERSION_CONSTRAINT}", f"ml_metadata{_TFXVERSION_CONSTRAINT}"],
+    "mlmd_client": [
+        f"ml_pipelines_sdk{_TFXVERSION_CONSTRAINT}",
+        f"ml_metadata{_TFXVERSION_CONSTRAINT}"
+    ],
     "schema_curation": [
         f"tfx{_TFXVERSION_CONSTRAINT}",
     ],
@@ -52,7 +51,7 @@ _PKG_METADATA = {
         "feast>=0.16.0,<1.0.0",
     ],
     "xgboost_evaluator": [
-         f"tfx{_TFXVERSION_CONSTRAINT}",
+        f"tfx{_TFXVERSION_CONSTRAINT}",
         "xgboost>=1.0.0",
     ],
     "sampling": [f"tfx{_TFXVERSION_CONSTRAINT}", "tensorflow>=2.0.0"],

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -56,7 +56,8 @@ _PKG_METADATA = {
     ],
     "sampling": [f"tfx{_TFXVERSION_CONSTRAINT}", "tensorflow>=2.0.0"],
     "message_exit_handler": [
-        f"tfx[kfp]{_TFXVERSION_CONSTRAINT}",
+        f"tfx{_TFXVERSION_CONSTRAINT}",
+        "kfp>=1.8,<2",
         "slackclient>=2.9.0",
         "pydantic>=1.8.0",
     ],

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -57,7 +57,7 @@ _PKG_METADATA = {
     ],
     "sampling": [f"tfx{_TFXVERSION_CONSTRAINT}", "tensorflow>=2.0.0"],
     "message_exit_handler": [
-        f"tfx{_TFXVERSION_CONSTRAINT}",
+        f"tfx[kfp]{_TFXVERSION_CONSTRAINT}",
         "slackclient>=2.9.0",
         "pydantic>=1.8.0",
     ],

--- a/tfx_addons/xgboost_evaluator/__init__.py
+++ b/tfx_addons/xgboost_evaluator/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-__all__ = [
-    "XGBoostEvaluator"
-]
+"""XGBoost evaluator module"""
+__all__ = ["XGBoostEvaluator"]
 from .component import XGBoostEvaluator

--- a/tfx_addons/xgboost_evaluator/xgboost_predict_extractor.py
+++ b/tfx_addons/xgboost_evaluator/xgboost_predict_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -108,10 +108,7 @@ class _TFMAPredictionDoFn(DoFnWithModels):
   def extract_model_specs(self):
     label_specs = {}
     for config in self._eval_config.model_specs:
-      if config.name:
-        label_specs[config.name] = config.label_key
-      else:  # if the input name to ModelSpec is None, ModelSpec doesn't save it and config.name resolves to ''.
-        label_specs[None] = config.label_key
+      label_specs[config.name] = config.label_key
     return label_specs
 
   def process(self, elem: tfma.Extracts) -> Iterable[tfma.Extracts]:

--- a/tfx_addons/xgboost_evaluator/xgboost_predict_extractor_test.py
+++ b/tfx_addons/xgboost_evaluator/xgboost_predict_extractor_test.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,11 +40,11 @@ class XGBoostPredictExtractorTest(
     self._eval_export_dir = os.path.join(self._getTempDir(), 'eval_export')
     self._create_xgboost_model(self._eval_export_dir)
     self._eval_config = tfma.EvalConfig(
-        model_specs=[tfma.ModelSpec(name=None, label_key="label")])
+        model_specs=[tfma.ModelSpec(name='', label_key="label")])
     self._eval_shared_model = (
         xgboost_predict_extractor.custom_eval_shared_model(
             eval_saved_model_path=self._eval_export_dir,
-            model_name=None,
+            model_name='',
             eval_config=self._eval_config))
     self._schema = text_format.Parse(
         """


### PR DESCRIPTION
This is quite large change, but mostly it just includes a refactor TFX Addons README. Due to that, I had to restructure some parts of CI. Also I'm adding an easier way to import modules by doing `import tfx_addons as tfxa` similar to how tf-addons and tfx style does it. This should also give us more control over how to expose modules in tfxaddons while still develop in the repo.

Finally in the process of testing this realized xgboost evaluator was broken so fixed it and added it to the xgboost_penguin test.

I can break this change into smaller pieces as well.