### PR TITLE
Cherry pick bot to backport changes

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,19 @@
+name: Cherry pick
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  cherry-pick:
+    name: Cherry Pick
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/cherry-pick')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Cherry Pick
+        uses: vendoo/gha-cherry-pick@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -5,7 +5,10 @@ on:
 jobs:
   cherry-pick:
     name: Cherry Pick
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/cherry-pick')
+    # Only cherry pick if user is a release manager
+    # NB(gcasassaez): We unfortunately have to use fromJSON as GitHub doesn't have a way to specify constant arrays 
+    # See:  https://github.community/t/passing-an-array-literal-to-contains-function-causes-syntax-error/17213/3
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/cherry-pick') && contains(fromJson('["casassg", "hanneshapke"]'), github.event.sender.login)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@ TFX Addons follows [Semantic Versioning 2.0](https://semver.org/) strategy.
 4. Create a new PR and merge an increase of `_MINOR_VERSION` number in `main` to get ready for next release.
 
 ## Patch releases
-1. Cherry-pick commits to `rX.Y` branch
+1. Cherry-pick commits to `rX.Y` branch. Release team can just port PR by commenting "/cherry-pick rX.Y" in a merged PR.
 2. Create new PR with increasing `_PATCH_VERSION` in `version.py` against `rX.Y` branch.
 	* Set the correct version and suffix in [version.py](https://github.com/tensorflow/tfx-addons/blob/master/tensorflow_addons/version.py).
 	* Ensure the proper minimum and maximum tested versions of TFX are set in [version.py](https://github.com/tensorflow/tfx-addons/blob/master/tfx_addons/version.py).


### PR DESCRIPTION
Adds https://github.com/vendoo/gha-cherry-pick to cherry pick commit back to previous versions for easier development (I want to avoid having to manually cherry pick commits to back port them to a release branch)

ToDo:
- Document usage for bot