### PR TITLE
Fix bad link in xgboost_evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ tfxa.feast_examplegen.FeastExampleGen(...)
 * [tfxa.mlmd_client](https://github.com/tensorflow/tfx-addons/tree/main/tfx_addons/mlmd_client) 
 * [tfxa.schema_curation](https://github.com/tensorflow/tfx-addons/tree/main/tfx_addons/schema_curation) 
 * [tfxa.feast_examplegen](https://github.com/tensorflow/tfx-addons/tree/main/tfx_addons/feast_examplegen) 
-* [tfxa.xgboost_evaluator](https://github.com/tensorflow/tfx-addons/tree/main/x_addons/xgboost_evaluator)
+* [tfxa.xgboost_evaluator](https://github.com/tensorflow/tfx-addons/tree/main/tfx_addons/xgboost_evaluator)
 * [tfxa.sampling](https://github.com/tensorflow/tfx-addons/tree/main/tfx_addons/sampling)
 * [tfxa.message_exit_handler](https://github.com/tensorflow/tfx-addons/tree/main/tfx_addons/message_exit_handler) 
 


### PR DESCRIPTION
Commit 93fd0062d962470a7c76998a51a7697d208a7dde didn't completely fix the link.