### PR TITLE
Bump feast version support

### DIFF
--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -55,8 +55,7 @@ _PKG_METADATA = {
     ],
     "feast_examplegen": [
         f"tfx{_TFXVERSION_CONSTRAINT}",
-        # ToDo(gcasassaez): Use new version of feast once https://github.com/feast-dev/feast/pull/2745 gets released
-        "feast@git+https://github.com/feast-dev/feast.git",
+        "feast>=0.21.3,<1.0.0",
     ],
     "xgboost_evaluator": [
         f"tfx{_TFXVERSION_CONSTRAINT}",


### PR DESCRIPTION
Use https://github.com/feast-dev/feast/releases/tag/v0.21.3 to have tfx-addons resolve with feast.