### PR TITLE
CI: Run all if event name is push

### DIFF
--- a/.github/workflows/ci_examples.yml
+++ b/.github/workflows/ci_examples.yml
@@ -6,6 +6,7 @@ on:
       - 'tfx_addons/**'
       - 'examples/**'
       - '.github/workflows/ci_examples.yml'
+      - '.github/workflows/filter_examples.py'
       - 'setup.py'
       - 'pyproject.toml'
     branches:
@@ -16,6 +17,7 @@ on:
       - 'tfx_addons/**'
       - 'examples/**'
       - '.github/workflows/ci_examples.yml'
+      - '.github/workflows/filter_examples.py'
       - 'setup.py'
       - 'pyproject.toml'
     branches:

--- a/.github/workflows/filter_examples.py
+++ b/.github/workflows/filter_examples.py
@@ -34,7 +34,7 @@ logging.getLogger().setLevel(logging.INFO)
 
 # Get event that triggered workflow
 # See: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "pull_request")
+GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "unknown")
 
 # NB(casassg): Files that if changed should trigger running CI for all examples.
 # This are files which are core and we want to avoid causing outages
@@ -71,8 +71,12 @@ def _get_affected_examples(affected_files: List[str]) -> List[str]:
   testable_examples = _get_testable_examples()
   logging.info("Found %s testable example folders", testable_examples)
   if GH_EVENT_NAME == "push":
-    logging.info("Found %s event name, running all projects", GH_EVENT_NAME)
+    logging.info("GitHub Action trigger is %s, running all projects",
+                 GH_EVENT_NAME)
     return testable_examples
+  else:
+    logging.info("GitHub Action trigger is %s, filtering projects",
+                 GH_EVENT_NAME)
   for run_all_file in RUN_ALL_FILES:
     if run_all_file in affected_files:
       logging.warning("Found change in %s, running all projects", run_all_file)

--- a/.github/workflows/filter_examples.py
+++ b/.github/workflows/filter_examples.py
@@ -32,6 +32,8 @@ from workflows import filter_projects  # pylint: disable=wrong-import-position
 
 logging.getLogger().setLevel(logging.INFO)
 
+GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "pull_request")
+
 # NB(casassg): Files that if changed should trigger running CI for all examples.
 # This are files which are core and we want to avoid causing outages
 # because of them
@@ -67,6 +69,9 @@ def _get_affected_examples(affected_files: List[str]) -> List[str]:
   logging.info("Found affected files: %s", affected_files)
   testable_examples = _get_testable_examples()
   logging.info("Found %s testable example folders", testable_examples)
+  if GH_EVENT_NAME == "push":
+    logging.info("Found %s event name, running all projects", GH_EVENT_NAME)
+    return testable_examples
   for run_all_file in RUN_ALL_FILES:
     if run_all_file in affected_files:
       logging.warning("Found change in %s, running all projects", run_all_file)

--- a/.github/workflows/filter_examples.py
+++ b/.github/workflows/filter_examples.py
@@ -39,7 +39,6 @@ GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "pull_request")
 # because of them
 RUN_ALL_FILES = [
     ".github/workflows/ci_examples.yml",
-    ".github/workflows/filter_examples.yml"
 ]
 
 

--- a/.github/workflows/filter_examples.py
+++ b/.github/workflows/filter_examples.py
@@ -32,6 +32,8 @@ from workflows import filter_projects  # pylint: disable=wrong-import-position
 
 logging.getLogger().setLevel(logging.INFO)
 
+# Get event that triggered workflow
+# See: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "pull_request")
 
 # NB(casassg): Files that if changed should trigger running CI for all examples.

--- a/.github/workflows/filter_projects.py
+++ b/.github/workflows/filter_projects.py
@@ -29,6 +29,7 @@ RUN_ALL_FILES = [
     "tfx_addons/version.py", "setup.py", ".github/workflows/ci.yml",
     "pyproject.toml"
 ]
+GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "pull_request")
 
 
 def _get_testable_projects() -> List[str]:
@@ -49,6 +50,9 @@ def get_affected_projects(affected_files: List[str]) -> List[str]:
 
   logging.info("Found affected files: %s", affected_files)
   testable_projects = _get_testable_projects()
+  if GH_EVENT_NAME == "push":
+    logging.info("Found %s event name, running all projects", GH_EVENT_NAME)
+    return testable_projects
   for run_all_file in RUN_ALL_FILES:
     if run_all_file in affected_files:
       logging.warning("Found change in %s, running all projects", run_all_file)

--- a/.github/workflows/filter_projects.py
+++ b/.github/workflows/filter_projects.py
@@ -32,7 +32,7 @@ RUN_ALL_FILES = [
 
 # Get event that triggered workflow
 # See: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "pull_request")
+GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "unknown")
 
 
 def _get_testable_projects() -> List[str]:
@@ -54,8 +54,12 @@ def get_affected_projects(affected_files: List[str]) -> List[str]:
   logging.info("Found affected files: %s", affected_files)
   testable_projects = _get_testable_projects()
   if GH_EVENT_NAME == "push":
-    logging.info("Found %s event name, running all projects", GH_EVENT_NAME)
+    logging.info("GitHub Action trigger is %s, running all projects",
+                 GH_EVENT_NAME)
     return testable_projects
+  else:
+    logging.info("GitHub Action trigger is %s, filtering projects",
+                 GH_EVENT_NAME)
   for run_all_file in RUN_ALL_FILES:
     if run_all_file in affected_files:
       logging.warning("Found change in %s, running all projects", run_all_file)

--- a/.github/workflows/filter_projects.py
+++ b/.github/workflows/filter_projects.py
@@ -29,6 +29,9 @@ RUN_ALL_FILES = [
     "tfx_addons/version.py", "setup.py", ".github/workflows/ci.yml",
     "pyproject.toml"
 ]
+
+# Get event that triggered workflow
+# See: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 GH_EVENT_NAME = os.environ.get("GITHUB_EVENT_NAME", "pull_request")
 
 


### PR DESCRIPTION
Make sure to run all CI if its a push event.

This ensures we have healthy release branches and main.
