### PR TITLE
fix: filter non-text files for text replacement

### DIFF
--- a/tfx_addons/huggingface_pusher/runner.py
+++ b/tfx_addons/huggingface_pusher/runner.py
@@ -36,8 +36,7 @@ _DEFAULT_MODEL_VERSION_PLACEHOLDER_KEY = "$MODEL_VERSION"
 
 
 def _is_text_file(path):
-  """check if a file in the given path is text type. Only the
-    contents inside text based files should be replaced"""
+  """check if a file in the given path is text type"""
   mimetype = mimetypes.guess_type(path)
   if mimetype[0] is not None:
     return 'text' in mimetype[0]
@@ -48,7 +47,8 @@ def _replace_placeholders_in_files(root_dir: str,
                                    placeholder_to_replace: Dict[str, str]):
   """Recursively open every files under the root_dir, and then
     replace special tokens with the given values in placeholder_
-    to_replace"""
+    to_replace. Only the contents inside text based files should
+    be replaced, so the file type is checked by _is_text_file."""
   files = tf.io.gfile.listdir(root_dir)
   for file in files:
     path = tf.io.gfile.join(root_dir, file)
@@ -63,7 +63,7 @@ def _replace_placeholders_in_file(filepath: str,
                                   placeholder_to_replace: Dict[str, str]):
   """replace special tokens with the given values in placeholder_
     to_replace. This function gets called by _replace_placeholders
-    _in_files function"""
+    _in_files function."""
   if _is_text_file(filepath):
     with tf.io.gfile.GFile(filepath, "r") as f:
       source_code = f.read()


### PR DESCRIPTION
I found a bug in the HFPusher component that tries to replace contents in a file with given text even if the file is a binary type. This causes an error, so I have added a simple filtering logic to identify only text based files.