### PR TITLE
Pin down feast dependency

### DIFF
--- a/.github/ci/.pre-commit-config.yaml
+++ b/.github/ci/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
     -   id: yapf 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.11.5
     hooks:
     -   id: isort
         name: isort (python)

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -32,14 +32,14 @@ if _VERSION_SUFFIX:
   __version__ = "{}-{}".format(__version__, _VERSION_SUFFIX)
 
 # Required TFX version [min, max)
-_INCLUSIVE_MIN_TFX_VERSION = "1.4.0"
+_INCLUSIVE_MIN_TFX_VERSION = "1.6.0"
 _EXCLUSIVE_MAX_TFX_VERSION = "1.11.0"
 _TFXVERSION_CONSTRAINT = (
     f">={_INCLUSIVE_MIN_TFX_VERSION},<{_EXCLUSIVE_MAX_TFX_VERSION}")
 _CI_MAX_CONSTRAINTS = ["tfx~=1.10.0", "tensorflow~=2.9.0"]
 _CI_MIN_CONSTRAINTS = [
-    f"tfx~={_INCLUSIVE_MIN_TFX_VERSION}", "tensorflow~=2.6.0",
-    "apache-beam[gcp]<2.35", "firebase-admin<5.0.3"
+    f"tfx~={_INCLUSIVE_MIN_TFX_VERSION}",
+    "tensorflow~=2.8.0",
 ]
 # This is a list of officially  maintained projects with their dependencies.
 # Any project added here will be automatically picked up on release.

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -58,8 +58,8 @@ _PKG_METADATA = {
     [f"tfx{_TFXVERSION_CONSTRAINT}", "scikit_learn>=1.0.2,<2.0.0"],
     "feast_examplegen": [
         f"tfx{_TFXVERSION_CONSTRAINT}",
-        # ToDo(gcasassaez): Relax this once we stop supporting 3.7
-        # feast 0.23 upgrades numpy to >=1.22 which is not supported on py 3.7 and conflicts w google libraries
+        # ToDo(gcasassaez): Relax this once we stop supporting python 3.7
+        # feast>=0.23 upgrades to numpy>=1.22 which does not work on 3.7
         "feast>=0.21.3,<0.23.0",
     ],
     "xgboost_evaluator": [
@@ -73,7 +73,7 @@ _PKG_METADATA = {
         "slackclient>=2.9.0,<3.0",
         "pydantic>=1.8.0,<2.0",
     ],
-    "pandas_transform": [f"tfx{_TFXVERSION_CONSTRAINT}", "pandas>=1.0.0<2.0"],
+    "pandas_transform": [f"tfx{_TFXVERSION_CONSTRAINT}", "pandas>=1.0.0,<2.0"],
     "firebase_publisher":
     [f"tfx{_TFXVERSION_CONSTRAINT}", "firebase-admin>=5.0.0,<6.0.0"],
     "huggingface_pusher":

--- a/tfx_addons/version.py
+++ b/tfx_addons/version.py
@@ -58,7 +58,9 @@ _PKG_METADATA = {
     [f"tfx{_TFXVERSION_CONSTRAINT}", "scikit_learn>=1.0.2,<2.0.0"],
     "feast_examplegen": [
         f"tfx{_TFXVERSION_CONSTRAINT}",
-        "feast>=0.21.3,<1.0.0",
+        # ToDo(gcasassaez): Relax this once we stop supporting 3.7
+        # feast 0.23 upgrades numpy to >=1.22 which is not supported on py 3.7 and conflicts w google libraries
+        "feast>=0.21.3,<0.23.0",
     ],
     "xgboost_evaluator": [
         f"tfx{_TFXVERSION_CONSTRAINT}",


### PR DESCRIPTION
Current last version may not resolve feast dep due to feast>=0.23 upgrading their numpy version which does not resolve on py 3.7.

This is an attempt to fix it before we drop py 3.7.

Updated minimal version supported which grants a new release but it was needed as I couldn't find a way to make it work with the existing versions without having to pin the entirety of Google repos.

Also had to upgrade isort in pre-commit due to an issue in the dependency as seen in https://github.com/home-assistant/core/issues/86892