### PR TITLE
Update CI to skip matrix if no job needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,13 @@ jobs:
     - name: Filter projects
       id: set-matrix
       run: |
-        echo "::set-output name=projects::$(python ./.github/workflows/filter_projects.py $HOME/files.json)"
+        echo "projects=$(python ./.github/workflows/filter_projects.py $HOME/files.json)" >> $GITHUB_OUTPUT
 
   ci:
     runs-on: ubuntu-latest
     needs: filter_projects
     timeout-minutes: 60
+    if: needs.filter_examples.outputs.projects != '[]'
     strategy:
       # Test for each project in parallel using ci_max and ci_min to ensure 
       # tested in range of tfx/tensorflow supported versions

--- a/.github/workflows/ci_examples.yml
+++ b/.github/workflows/ci_examples.yml
@@ -49,11 +49,12 @@ jobs:
     - name: Filter example projects
       id: set-matrix
       run: |
-        echo "::set-output name=projects::$(python ./.github/workflows/filter_examples.py $HOME/files.json)"
+        echo "projects=$(python ./.github/workflows/filter_examples.py $HOME/files.json)" >> $GITHUB_OUTPUT
   ci-examples:
     runs-on: ubuntu-latest
     needs: filter_examples
     timeout-minutes: 60
+    if: needs.filter_examples.outputs.projects != '[]'
     strategy:
       # Test for each project in parallel using ci_max and ci_min to ensure 
       # tested in range of tfx/tensorflow supported versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build-and-publish:
     name: Build TFX Addons PyPI package and release to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7


### PR DESCRIPTION
Switch to use new GITHUB_OUTPUT file instead and skip matrix if array is empty