### PR TITLE
Update file-changes-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         python-version: 3.7
     - name: Get Changed Files
       id: changed_files
-      uses: trilom/file-changes-action@v1.2.3
+      uses: trilom/file-changes-action@v1.2.4
       with:
         output: json
     - name: Filter projects

--- a/.github/workflows/ci_examples.yml
+++ b/.github/workflows/ci_examples.yml
@@ -43,7 +43,7 @@ jobs:
         python-version: 3.7
     - name: Get Changed Files
       id: changed_files
-      uses: trilom/file-changes-action@v1.2.3
+      uses: trilom/file-changes-action@v1.2.4
       with:
         output: json
     - name: Filter example projects


### PR DESCRIPTION
Seems 1.2.3 has a regression which is fixed in 1.2.4 which causes in some cases to 500 error when large PRs are submitted