### PR TITLE
Enable filtering features and metrics in the ModelCardGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ __pycache__/
 # C extensions
 **/*.so
 
+# Unit test
+.pytest_cache/
+
 # Distribution / packaging
 .Python
 # build/  # build/ contains required files for building tfx packages.
@@ -37,6 +40,9 @@ env/*
 **/env
 **/venv
 
-#Editor
+# pyenv
+.python-version
+
+# Editor
 .idea/*
 .vscode/*

--- a/tfx_addons/model_card_generator/component_test.py
+++ b/tfx_addons/model_card_generator/component_test.py
@@ -25,7 +25,7 @@ from tfx_addons.model_card_generator.component import ModelCardGenerator
 
 class ComponentTest(absltest.TestCase):
   def test_component_construction(self):
-    this_component = ModelCardGenerator(
+    model_card_gen = ModelCardGenerator(
         statistics=channel_utils.as_channel(
             [standard_artifacts.ExampleStatistics()]),
         evaluation=channel_utils.as_channel(
@@ -40,10 +40,11 @@ class ComponentTest(absltest.TestCase):
                 }
             }}),
         template_io=[('path/to/html/template', 'mc.html'),
-                     ('path/to/md/template', 'mc.md')])
+                     ('path/to/md/template', 'mc.md')],
+    )
 
     with self.subTest('outputs'):
-      self.assertEqual(this_component.outputs['model_card'].type_name,
+      self.assertEqual(model_card_gen.outputs['model_card'].type_name,
                        artifact.ModelCard.TYPE_NAME)
 
     with self.subTest('exec_properties'):
@@ -59,14 +60,56 @@ class ComponentTest(absltest.TestCase):
                   }
               }),
               'template_io': [('path/to/html/template', 'mc.html'),
-                              ('path/to/md/template', 'mc.md')]
-          }, this_component.exec_properties)
+                              ('path/to/md/template', 'mc.md')],
+              'features_include':
+              None,
+              'features_exclude':
+              None,
+              'metrics_include':
+              None,
+              'metrics_exclude':
+              None,
+          }, model_card_gen.exec_properties)
 
   def test_empty_component_construction(self):
-    this_component = ModelCardGenerator()
+    model_card_gen = ModelCardGenerator()
     with self.subTest('outputs'):
-      self.assertEqual(this_component.outputs['model_card'].type_name,
+      self.assertEqual(model_card_gen.outputs['model_card'].type_name,
                        artifact.ModelCard.TYPE_NAME)
+
+  def test_component_construction_with_filtered_features(self):
+    model_card_gen = ModelCardGenerator(features_include=['feature_name1'])
+    self.assertEqual(model_card_gen.exec_properties['features_include'],
+                     ['feature_name1'])
+
+    model_card_gen_features_exclude = ModelCardGenerator(
+        features_exclude=['feature_name2'], )
+    self.assertEqual(
+        model_card_gen_features_exclude.exec_properties['features_exclude'],
+        ['feature_name2'])
+
+    with self.assertRaises(ValueError):
+      ModelCardGenerator(
+          features_include=['feature_name1'],
+          features_exclude=['feature_name2'],
+      )
+
+  def test_component_construction_with_filtered_metrics(self):
+    model_card_gen = ModelCardGenerator(metrics_include=['accuracy'])
+    self.assertEqual(model_card_gen.exec_properties['metrics_include'],
+                     ['accuracy'])
+
+    model_card_gen_metrics_exclude = ModelCardGenerator(
+        metrics_exclude=['loss'], )
+    self.assertEqual(
+        model_card_gen_metrics_exclude.exec_properties['metrics_exclude'],
+        ['loss'])
+
+    with self.assertRaises(ValueError):
+      ModelCardGenerator(
+          metrics_include=['accuracy'],
+          metrics_exclude=['loss'],
+      )
 
 
 if __name__ == '__main__':

--- a/tfx_addons/model_card_generator/executor.py
+++ b/tfx_addons/model_card_generator/executor.py
@@ -33,23 +33,35 @@ class Executor(BaseExecutor):
   """Executor for Model Card TFX component."""
   def _tfma_source(
       self,
-      input_dict: Dict[str, List[types.Artifact]]) -> Optional[src.TfmaSource]:
+      input_dict: Dict[str, List[types.Artifact]],
+      exec_properties: Dict[str, Any],
+  ) -> Optional[src.TfmaSource]:
     """See base class."""
     if not input_dict.get(standard_component_specs.EVALUATION_KEY):
       return None
     else:
-      return src.TfmaSource(model_evaluation_artifacts=input_dict[
-          standard_component_specs.EVALUATION_KEY])
+      return src.TfmaSource(
+          model_evaluation_artifacts=input_dict[
+              standard_component_specs.EVALUATION_KEY],
+          metrics_include=exec_properties.get('metrics_include', []),
+          metrics_exclude=exec_properties.get('metrics_exclude', []),
+      )
 
   def _tfdv_source(
       self,
-      input_dict: Dict[str, List[types.Artifact]]) -> Optional[src.TfdvSource]:
+      input_dict: Dict[str, List[types.Artifact]],
+      exec_properties: Dict[str, Any],
+  ) -> Optional[src.TfdvSource]:
     """See base class."""
     if not input_dict.get(standard_component_specs.STATISTICS_KEY):
       return None
     else:
-      return src.TfdvSource(example_statistics_artifacts=input_dict[
-          standard_component_specs.STATISTICS_KEY])
+      return src.TfdvSource(
+          example_statistics_artifacts=input_dict[
+              standard_component_specs.STATISTICS_KEY],
+          features_include=exec_properties.get('features_include', []),
+          features_exclude=exec_properties.get('features_exclude', []),
+      )
 
   def _model_source(
       self,
@@ -100,13 +112,28 @@ class Executor(BaseExecutor):
           `ModelCardToolkit`'s default HTML template
           (`default_template.html.jinja`) and file name (`model_card.html`)
           are used.
+        - features_include: The feature paths to include for the dataset
+          statistics.
+          By default, all features are included. Mutually exclusive with
+          features_exclude.
+        - features_exclude: The feature paths to exclude for the dataset
+          statistics.
+          By default, all features are included. Mutually exclusive with
+          features_include.
+        - metrics_include: The list of metric names to include in the model
+          card. By default, all metrics are included. Mutually exclusive with
+          metrics_exclude.
+        - metrics_exclude: The list of metric names to exclude in the model
+          card. By default, no metrics are excluded. Mutually exclusive with
+          metrics_include.
     """
 
     # Initialize ModelCardToolkit
     mct = core.ModelCardToolkit(source=src.Source(
-        tfma=self._tfma_source(input_dict),
-        tfdv=self._tfdv_source(input_dict),
-        model=self._model_source(input_dict)),
+        tfma=self._tfma_source(input_dict, exec_properties),
+        tfdv=self._tfdv_source(input_dict, exec_properties),
+        model=self._model_source(input_dict),
+    ),
                                 output_dir=artifact_utils.get_single_instance(
                                     output_dict['model_card']).uri)
     template_io = exec_properties.get('template_io') or [


### PR DESCRIPTION
Model Card Toolkit supports filtering features and metrics when annotating a model card. This change surfaces `features_include`, `features_exclude`, `metrics_include`, and `metrics_exclude` parameters to enable filtering features and metrics through the `ModelCardGenerator` component as well.

Fixes [issue reported in the tfxa Google Group](https://groups.google.com/a/tensorflow.org/g/sig-tfx-addons/c/xV_ltbl0K24/m/AKQe_HgOAQAJ).

- [x] Tests pass
- [x] Appropriate changes to README are included in PR