### PR TITLE
Fix typo in `tfx_addons/model_card_generator/component.py`

### DIFF
--- a/tfx_addons/model_card_generator/component.py
+++ b/tfx_addons/model_card_generator/component.py
@@ -66,7 +66,7 @@ class ModelCardGenerator(BaseComponent):
   that generates model cards.
 
   The model cards are written to a `ModelCard` artifact that can be fetched
-  from the `outputs['model_card]'` property.
+  from the `outputs['model_card']` property.
 
   Example:
 


### PR DESCRIPTION
Fix the typo in the ModelCardGenerator component.